### PR TITLE
feat(auth): revalidate JWT session on app hydrate

### DIFF
--- a/lib/auth-provider.tsx
+++ b/lib/auth-provider.tsx
@@ -57,20 +57,31 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   useEffect(() => {
-    if (typeof window !== "undefined") {
-      try {
-        const storedUser = localStorage.getItem("auth_user");
-        const storedToken = localStorage.getItem("auth_token");
-        if (storedUser && storedToken) {
-          setUser(JSON.parse(storedUser));
-          setToken(storedToken);
-        }
-      } catch (e) {
-        console.error("Failed to hydrate auth state", e);
-      }
+    if (typeof window === "undefined") return;
+
+    const storedToken = localStorage.getItem("auth_token");
+    if (!storedToken) {
       setHydrated(true);
+      return;
     }
-  }, []);
+
+    fetch("/api/auth/me", {
+      headers: { Authorization: `Bearer ${storedToken}` },
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error("Invalid token");
+        return res.json();
+      })
+      .then((data) => {
+        login(data.user, storedToken);
+      })
+      .catch(() => {
+        logout();
+      })
+      .finally(() => {
+        setHydrated(true);
+      });
+  }, [login, logout]);
 
   return (
     <AuthContext.Provider value={{ user, token, hydrated, login, logout }}>


### PR DESCRIPTION
  ## Summary

  - Async JWT revalidation on app hydrate — resolves [FE] #61
  - `AuthProvider` now calls `GET /api/auth/me` on every page load before setting `hydrated = true`
  - Expired, revoked, or malformed tokens trigger automatic logout instead of a stale logged-in state
  - Mirrors the pattern already used in `app/auth/callback/success/page.tsx`

  ## What changed

  **`lib/auth-provider.tsx`**
  - Replaced synchronous localStorage restore with an async fetch to `/api/auth/me`
  - `hydrated` is set to `true` only after server validation completes (no dashboard flash while "logged in" with stale
  auth)
  - On 401 / any error → `logout()` clears state and localStorage automatically
  - On success → `login(data.user, token)` refreshes state with server-confirmed user data
  - No token in storage → sets `hydrated = true` immediately (no unnecessary fetch)

  ## How to reproduce / test locally

  1. Log in and open **DevTools → Application → Local Storage**
  2. **Expired/corrupt token**: change `auth_token` to any invalid string → hard reload → you are logged out
  automatically
  3. **Valid token**: hard reload normally → session is restored correctly, no unauthenticated flash
  4. **No token**: clear `auth_token` from storage → reload → logged out, no flash

  Closes #61
  
  
  
<img width="1712" height="1045" alt="Screenshot 2026-06-19 at 4 47 25 PM" src="https://github.com/user-attachments/assets/a761cae3-21a1-4bdb-9cd5-d44fd3183924" />


<img width="1706" height="1042" alt="Screenshot 2026-06-19 at 5 15 55 PM" src="https://github.com/user-attachments/assets/838fd7be-96d9-48f3-a7ce-87ff7bdf8ea0" />


<img width="1712" height="1045" alt="Screenshot 2026-06-19 at 4 47 25 PM" src="https://github.com/user-attachments/assets/536fea95-e3cc-4b9f-b3ec-172f8171ed85" />

