### PR TITLE
fix(auth): stop creating orphan wallet on signup; make wallet_public_…

### DIFF
--- a/app/api/auth/oauth-callback/route.ts
+++ b/app/api/auth/oauth-callback/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from "next/server";
 import { createServiceClient } from "@/lib/supabase/service";
 import { signToken, type AuthUser } from "@/lib/auth/utils";
-import { Keypair } from "stellar-sdk";
-import { activateAndAddTrustline } from "@/lib/stellar/trustline";
 
 export async function POST(req: Request) {
   const body = await req.json().catch(() => ({}));
@@ -36,7 +34,7 @@ export async function POST(req: Request) {
     .maybeSingle();
 
   let userId: string;
-  let walletPublicKey: string;
+  let walletPublicKey: string | null;
   let userName: string | undefined = name;
 
   if (existing) {
@@ -44,24 +42,16 @@ export async function POST(req: Request) {
     walletPublicKey = existing.wallet_public_key;
     if (existing.name) userName = existing.name;
   } else {
-    const keypair = Keypair.random();
-    walletPublicKey = keypair.publicKey();
-    const walletSecretKey = keypair.secret();
-    
-    // Activate wallet and add USDC trustline before saving
-    const trustlineResult = await activateAndAddTrustline(walletPublicKey, walletSecretKey);
-    if (!trustlineResult.success) {
-      console.warn("Failed to activate wallet/trustline for OAuth user:", trustlineResult.error);
-      // Continue with registration even if trustline fails
-    }
-    
+    // OAuth signup creates the identity only. No wallet is generated — the
+    // user connects their own wallet later (M2 flow).
+    walletPublicKey = null;
+
     const { data: inserted, error: insertError } = await db
       .from("auth_users")
       .insert({
         email,
         password_hash: null,
         name: name ?? null,
-        wallet_public_key: walletPublicKey,
         auth_provider: "oauth",
       })
       .select("id, name")

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -72,6 +72,11 @@ export async function POST(req: Request) {
   // The custodial-wallet link and the wallet-keyed profile row are intentionally
   // not created here. They depend on a wallet, which the user now connects later
   // (M2 flow), so they belong to the wallet-connect step rather than signup.
+  //
+  // account_type (personal/enterprise) is not dropped: it is no longer persisted
+  // at signup (it lived on the wallet-keyed profile) and is instead set at the
+  // profile-selection / wallet-connect step (#1.4). Signup must not break without
+  // it, which is why nothing here depends on a wallet or profile.
 
   const user: AuthUser = {
     id: inserted.id,

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,12 +1,10 @@
 import { NextResponse } from "next/server";
-import { Keypair } from "stellar-sdk";
 import { createServiceClient } from "@/lib/supabase/service";
 import {
   hashPassword,
   signToken,
   type AuthUser,
 } from "@/lib/auth/utils";
-import { activateAndAddTrustline } from "@/lib/stellar/trustline";
 
 function validateEmail(email: unknown): email is string {
   return typeof email === "string" && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
@@ -21,7 +19,6 @@ export async function POST(req: Request) {
   const email = body.email;
   const password = body.password;
   const name = typeof body.name === "string" ? body.name : undefined;
-  const accountType = body.accountType === "enterprise" ? "enterprise" : "personal";
 
   if (!validateEmail(email)) {
     return NextResponse.json(
@@ -51,28 +48,17 @@ export async function POST(req: Request) {
   }
 
   const password_hash = await hashPassword(password);
-  const keypair = Keypair.random();
-  const wallet_public_key = keypair.publicKey();
-  const wallet_secret_key = keypair.secret();
 
-  // Activate wallet and add USDC trustline before saving
-  // This ensures the custodial wallet can receive USDC payments
-  const trustlineResult = await activateAndAddTrustline(wallet_public_key, wallet_secret_key);
-  if (!trustlineResult.success) {
-    console.warn("Failed to activate wallet/trustline:", trustlineResult.error);
-    // Continue with registration even if trustline fails
-    // User can add trustline later
-  }
-
+  // Signup creates the identity only. No wallet is generated here — the user
+  // connects their own wallet later (M2 flow), so wallet_public_key stays null.
   const { data: inserted, error } = await supabase
     .from("auth_users")
     .insert({
       email: email.trim().toLowerCase(),
       password_hash,
       name: name ?? null,
-      wallet_public_key,
     })
-    .select("id, email, name, wallet_public_key")
+    .select("id, email, name")
     .single();
 
   if (error) {
@@ -83,41 +69,15 @@ export async function POST(req: Request) {
     );
   }
 
-  // Auto-link the custodial wallet to the user's linked_wallets
-  const { error: linkError } = await supabase
-    .from("linked_wallets")
-    .insert({
-      user_id: inserted.id,
-      wallet_address: wallet_public_key,
-      wallet_type: "custodial",
-      label: "Email Wallet",
-      is_primary: true,
-    });
-
-  if (linkError) {
-    console.warn("Failed to auto-link custodial wallet:", linkError);
-    // Continue anyway - user can link it manually
-  }
-
-  // Create profile with account_type
-  const { error: profileError } = await supabase
-    .from("profiles")
-    .upsert({
-      wallet_address: wallet_public_key,
-      email: email.trim().toLowerCase(),
-      display_name: name,
-      account_type: accountType,
-    }, { onConflict: "wallet_address" });
-
-  if (profileError) {
-    console.warn("Failed to create profile:", profileError);
-  }
+  // The custodial-wallet link and the wallet-keyed profile row are intentionally
+  // not created here. They depend on a wallet, which the user now connects later
+  // (M2 flow), so they belong to the wallet-connect step rather than signup.
 
   const user: AuthUser = {
     id: inserted.id,
     email: inserted.email,
     name: inserted.name ?? undefined,
-    wallet: { publicKey: inserted.wallet_public_key, type: "embedded" },
+    wallet: { publicKey: null },
   };
   const token = signToken({ sub: inserted.id, email: inserted.email });
   return NextResponse.json({ user, token });

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -2,8 +2,6 @@ import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { createServiceClient } from "@/lib/supabase/service";
 import { signToken } from "@/lib/auth/utils";
-import { Keypair } from "stellar-sdk";
-import { activateAndAddTrustline } from "@/lib/stellar/trustline";
 
 /**
  * Server-side OAuth callback. The code verifier is in the request cookies
@@ -45,44 +43,40 @@ export async function GET(req: Request) {
       .maybeSingle();
 
     let userId: string;
-    let walletPublicKey: string;
+    let walletPublicKey: string | null;
     let userName: string | undefined = name;
 
     let accountType: string | null = null;
-    
+
     if (existing) {
       userId = existing.id;
       walletPublicKey = existing.wallet_public_key;
       if (existing.name) userName = existing.name;
-      
-      // Check if user has a profile with account_type
-      const { data: profile } = await db
-        .from("profiles")
-        .select("account_type")
-        .eq("wallet_address", walletPublicKey)
-        .maybeSingle();
-      
-      if (profile?.account_type) {
-        accountType = profile.account_type;
+
+      // Check if user has a profile with account_type (only if a wallet is set)
+      if (walletPublicKey) {
+        const { data: profile } = await db
+          .from("profiles")
+          .select("account_type")
+          .eq("wallet_address", walletPublicKey)
+          .maybeSingle();
+
+        if (profile?.account_type) {
+          accountType = profile.account_type;
+        }
       }
     } else {
-      const keypair = Keypair.random();
-      walletPublicKey = keypair.publicKey();
-      const walletSecretKey = keypair.secret();
-      
-      // Activate wallet and add USDC trustline for new users
-      const trustlineResult = await activateAndAddTrustline(walletPublicKey, walletSecretKey);
-      if (!trustlineResult.success) {
-        console.warn("Failed to activate wallet/trustline for OAuth user:", trustlineResult.error);
-      }
-      
+      // OAuth signup creates the identity only. No wallet is generated and no
+      // custodial wallet is auto-linked — the user connects their own wallet
+      // later (M2 flow).
+      walletPublicKey = null;
+
       const { data: inserted, error: insertError } = await db
         .from("auth_users")
         .insert({
           email,
           password_hash: null,
           name: name ?? null,
-          wallet_public_key: walletPublicKey,
           auth_provider: "oauth",
         })
         .select("id, name")
@@ -95,17 +89,6 @@ export async function GET(req: Request) {
       }
       userId = inserted.id;
       if (inserted.name) userName = inserted.name;
-      
-      // Auto-link the custodial wallet for new OAuth users
-      await db
-        .from("linked_wallets")
-        .insert({
-          user_id: userId,
-          wallet_address: walletPublicKey,
-          wallet_type: "custodial",
-          label: "Email Wallet",
-          is_primary: true,
-        });
     }
 
     // Determine redirect: if user has account_type, go to dashboard; otherwise select-profile

--- a/lib/auth/utils.ts
+++ b/lib/auth/utils.ts
@@ -8,7 +8,7 @@ export interface AuthUser {
   id: string;
   email: string;
   name?: string;
-  wallet: { publicKey: string; type?: string };
+  wallet: { publicKey: string | null; type?: string };
 }
 
 export interface AuthResponse {

--- a/scripts/006_auth_users.sql
+++ b/scripts/006_auth_users.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS auth_users (
   email TEXT UNIQUE NOT NULL,
   password_hash TEXT NOT NULL,
   name TEXT,
-  wallet_public_key TEXT NOT NULL,
+  wallet_public_key TEXT,
   created_at TIMESTAMPTZ DEFAULT NOW(),
   updated_at TIMESTAMPTZ DEFAULT NOW()
 );

--- a/scripts/011_auth_users_wallet_nullable.sql
+++ b/scripts/011_auth_users_wallet_nullable.sql
@@ -1,0 +1,7 @@
+-- Make auth_users.wallet_public_key nullable.
+--
+-- Signup now creates the account/identity only, with no wallet assigned
+-- (no more orphan custodial wallets). Users connect their own wallet later
+-- via the M2 flow, so a freshly created auth_users row starts with
+-- wallet_public_key = NULL.
+ALTER TABLE auth_users ALTER COLUMN wallet_public_key DROP NOT NULL;


### PR DESCRIPTION
Closes #71

## What this does
Signup previously generated a random Stellar keypair, threw away the secret key, and stored the public key as an unusable "orphan" wallet. Signing up now creates the account/identity only. The user connects their own wallet later (M2 flow).

## Changes
- Removed `Keypair.random()` + `activateAndAddTrustline` from all three auth routes (`api/auth/register`, `api/auth/oauth-callback`, `auth/callback`).
- Stopped auto-linking a custodial wallet to `linked_wallets` on signup.
- New `auth_users` rows are inserted with no `wallet_public_key` (NULL).
- Migration `scripts/011_auth_users_wallet_nullable.sql` drops the NOT NULL constraint; `006_auth_users.sql` updated so fresh installs match.
- `AuthUser.wallet.publicKey` is now `string | null` so login/session keeps working for accounts without a wallet (JWT `sub` = `auth_users.id`, unchanged).

## Question / decision to confirm
The `register` route also upserted a `profiles` row keyed by the wallet address, and `profiles.wallet_address` is `UNIQUE NOT NULL`. Since signup no longer creates a wallet, a profile row can't be created at signup. I deferred the profile creation (and the custodial `linked_wallets` row) to the wallet-connect flow (#72), which keeps signup as identity-only per the issue. Happy to handle this differently if you'd prefer.

## How to test
1. Apply the migration: run `scripts/011_auth_users_wallet_nullable.sql` on the dev Supabase.
2. `pnpm run build` (passes).
3. Sign up via email or OAuth, then check `auth_users` — the new row has `wallet_public_key = NULL` (no orphan wallet).
4. Log in with the new account — session/JWT works as before.

## Acceptance criteria
- [x] New signup creates an account with NO orphan wallet
- [x] `auth_users.wallet_public_key` is nullable; new rows can be null
- [x] No `Keypair.random()` remains in the auth routes
- [x] Existing login/session still works
- [x] `pnpm run build` passes