### PR TITLE
feat: gate escrow actions behind verified wallet check

### DIFF
--- a/app/dashboard/business/page.tsx
+++ b/app/dashboard/business/page.tsx
@@ -11,7 +11,8 @@ import { ThalosLoader } from "@/components/thalos-loader"
 import { LanguageToggle, ThemeToggle, useLanguage } from "@/lib/i18n"
 import { Footer } from "@/components/footer"
 import { useStellarWallet } from "@/lib/stellar-wallet"
-import { useCurrentAddress } from "@/lib/use-current-address"
+import { useCurrentAddress, useWalletType } from "@/lib/use-current-address"
+import { WalletGuard, WalletPrompt } from "@/components/shared/wallet-guard"
 import { useAuthStore } from "@/lib/auth-store"
 import { WalletAddress } from "@/components/ui/wallet-address"
 import { getProfileByWallet, type Profile } from "@/lib/actions/profile"
@@ -241,6 +242,8 @@ export default function BusinessDashboardPage() {
   const { t, theme } = useLanguage()
   const isLight = theme === "light"
   const { openWalletModal, address: walletAddress } = useStellarWallet()
+  const walletType = useWalletType()
+  const isExternalWallet = walletType === "external"
   const [loading, setLoading] = useState(false)
 
   const [activeSection, setActiveSection] = useState("agreements")
@@ -1128,13 +1131,19 @@ export default function BusinessDashboardPage() {
                         <div className="flex items-center gap-3">
                           <p className="text-lg font-bold text-white">{"$"}{ms.amount} <span className="text-xs font-normal text-white/35">USDC</span></p>
                           {ms.status === "pending" && !allReleased && activePermissions.approve && (
-                            <Button size="sm" onClick={() => approveMilestone(agr.id, idx)}
+                            <Button size="sm" onClick={() => {
+                              if (!isExternalWallet) { openWalletModal(); return }
+                              approveMilestone(agr.id, idx)
+                            }}
                               className="rounded-full bg-white/10 px-4 text-xs font-semibold text-white hover:bg-white/20">
                               Approve
                             </Button>
                           )}
                           {ms.status === "approved" && agr.releaseStrategy === "per-milestone" && activePermissions.release && (
-                            <Button size="sm" onClick={() => releaseMilestone(agr.id, idx)}
+                            <Button size="sm" onClick={() => {
+                              if (!isExternalWallet) { openWalletModal(); return }
+                              releaseMilestone(agr.id, idx)
+                            }}
                               className="rounded-full bg-[#3b82f6] px-4 text-xs font-semibold text-white hover:bg-[#2563eb] shadow-[0_2px_8px_rgba(59,130,246,0.2)]">
                               Release Funds
                             </Button>
@@ -1142,7 +1151,10 @@ export default function BusinessDashboardPage() {
                           {ms.status !== "released" && !disputedMs.has(`${agr.id}-${idx}`) && (
                             <Button 
                               size="sm" 
-                              onClick={() => setShowDisputeConfirm({ agrId: agr.id, msIdx: idx })}
+                              onClick={() => {
+                                if (!isExternalWallet) { openWalletModal(); return }
+                                setShowDisputeConfirm({ agrId: agr.id, msIdx: idx })
+                              }}
                               className="rounded-full bg-red-500/10 px-3 text-xs font-semibold text-red-400 hover:bg-red-500/20 border border-red-500/20"
                             >
                               <AlertTriangle className="h-3 w-3 mr-1" />
@@ -1158,30 +1170,42 @@ export default function BusinessDashboardPage() {
                   ))}
                 </div>
 
-                {!allReleased && (activePermissions.approve || activePermissions.release) && (
+                {!allReleased && (activePermissions.approve || activePermissions.release) && isExternalWallet && (
                   <div className="rounded-2xl border border-white/10 bg-[#0c1220] p-6 shadow-[0_8px_32px_rgba(0,0,0,0.4),inset_0_1px_0_rgba(255,255,255,0.05)]">
                     <h3 className="mb-4 text-sm font-bold uppercase tracking-wider text-white/40">Release Actions</h3>
                     <div className="flex flex-wrap gap-3">
                       {agr.type === "Single Release" && agr.milestones[0]?.status === "pending" && activePermissions.approve && (
-                        <Button onClick={() => approveMilestone(agr.id, 0)}
+                        <Button onClick={() => {
+                          if (!isExternalWallet) { openWalletModal(); return }
+                          approveMilestone(agr.id, 0)
+                        }}
                           className="rounded-full bg-white/10 px-6 text-sm font-semibold text-white hover:bg-white/20">
                           Approve Agreement
                         </Button>
                       )}
                       {agr.type === "Single Release" && agr.milestones[0]?.status === "approved" && activePermissions.release && (
-                        <Button onClick={() => releaseMilestone(agr.id, 0)}
+                        <Button onClick={() => {
+                          if (!isExternalWallet) { openWalletModal(); return }
+                          releaseMilestone(agr.id, 0)
+                        }}
                           className="rounded-full bg-[#3b82f6] px-6 text-sm font-semibold text-white hover:bg-[#2563eb] shadow-[0_4px_16px_rgba(59,130,246,0.25)]">
                           Release All Funds
                         </Button>
                       )}
                       {agr.type === "Multi Release" && hasApproved && activePermissions.release && (
-                        <Button onClick={() => releaseAllApproved(agr.id)}
+                        <Button onClick={() => {
+                          if (!isExternalWallet) { openWalletModal(); return }
+                          releaseAllApproved(agr.id)
+                        }}
                           className="rounded-full bg-[#3b82f6] px-6 text-sm font-semibold text-white hover:bg-[#2563eb] shadow-[0_4px_16px_rgba(59,130,246,0.25)]">
                           Release All Approved
                         </Button>
                       )}
                       {agr.type === "Multi Release" && !allApproved && activePermissions.approve && activePermissions.release && (
-                        <Button onClick={() => approveAndReleaseAll(agr.id)}
+                        <Button onClick={() => {
+                          if (!isExternalWallet) { openWalletModal(); return }
+                          approveAndReleaseAll(agr.id)
+                        }}
                           className="rounded-full bg-emerald-600 px-6 text-sm font-semibold text-white hover:bg-emerald-700 shadow-[0_4px_16px_rgba(16,185,129,0.2)]">
                           Approve & Release All
                         </Button>
@@ -1189,6 +1213,11 @@ export default function BusinessDashboardPage() {
                     </div>
                     <p className="mt-3 text-xs text-white/25">Receiver wallet: <span className="font-mono">{agr.receiver.substring(0, 8)}...{agr.receiver.substring(agr.receiver.length - 6)}</span></p>
                   </div>
+                )}
+                {!allReleased && (activePermissions.approve || activePermissions.release) && !isExternalWallet && (
+                  <WalletPrompt
+                    message="Connect and verify a wallet to approve or release funds on this agreement."
+                  />
                 )}
 
                 {allReleased && (
@@ -1410,6 +1439,14 @@ export default function BusinessDashboardPage() {
           {/* ══════ CREATE AGREEMENT ══════ */}
           {activeSection === "create" && activePermissions.create && (
             <div className="mx-auto max-w-4xl animate-in fade-in slide-in-from-bottom-2 duration-300">
+              {!isExternalWallet && !submitted ? (
+                <div className="pt-8">
+                  <WalletPrompt
+                    message="Connect and verify a wallet to operate escrow agreements on Thalos."
+                  />
+                </div>
+              ) : (
+              <>
               <div className="mb-6 flex items-center justify-between">
                 <h1 className="text-2xl font-semibold text-white">New Agreement</h1>
                 <Button onClick={() => { setActiveSection("agreements"); resetWizard() }} className="rounded-full bg-white/10 px-6 text-sm font-semibold text-white/70 hover:bg-white/15 hover:text-white">View Agreements</Button>
@@ -1611,6 +1648,8 @@ export default function BusinessDashboardPage() {
                     )}
                   </div>
                 </div>
+              )}
+              </>
               )}
             </div>
           )}

--- a/app/dashboard/personal/ApproverAgreementDetail.tsx
+++ b/app/dashboard/personal/ApproverAgreementDetail.tsx
@@ -25,10 +25,16 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { statusConfig } from "./statusConfig";
 import { useLanguage } from "@/lib/i18n";
+import { useWalletType } from "@/lib/use-current-address";
+import { useStellarWallet } from "@/lib/stellar-wallet";
+import { WalletPrompt } from "@/components/shared/wallet-guard";
 import { fundAndSignEscrow } from "@/lib/agreementActions";
 import { AlertTriangle } from "lucide-react";
 
 export function ApproverAgreementDetail({ agr, walletAddress }: ApproverAgreementDetailProps) {
+  const walletType = useWalletType();
+  const { openWalletModal } = useStellarWallet();
+  const isExternalWallet = walletType === "external";
   const [showDetail, setShowDetail] = React.useState(false);
   const [loadingMs, setLoadingMs] = React.useState<number | null>(null);
   const [errorMs, setErrorMs] = React.useState<string | null>(null);
@@ -224,7 +230,7 @@ export function ApproverAgreementDetail({ agr, walletAddress }: ApproverAgreemen
       </div>
 
       {/* Fund Escrow button (step 1) */}
-      {!isFunded && !allReleased && (
+      {!isFunded && !allReleased && isExternalWallet && (
         <div className="mt-4 rounded-xl border border-blue-500/15 bg-blue-500/5 p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
           <div>
             <p className="text-sm font-semibold text-white">{t("flow.fundEscrow")}</p>
@@ -248,6 +254,12 @@ export function ApproverAgreementDetail({ agr, walletAddress }: ApproverAgreemen
             {funding ? t("flow.funding") : t("flow.fundEscrow")}
           </Button>
         </div>
+      )}
+      {!isFunded && !allReleased && !isExternalWallet && (
+        <WalletPrompt
+          message="Connect and verify a wallet to fund this escrow agreement."
+          onConnect={openWalletModal}
+        />
       )}
       {fundError && <div className="text-red-400 text-xs mt-2">{fundError}</div>}
       {fundSuccess && <div className="text-emerald-400 text-xs mt-2">{t("flow.funded")} - Escrow funded successfully!</div>}
@@ -280,7 +292,7 @@ export function ApproverAgreementDetail({ agr, walletAddress }: ApproverAgreemen
                   
                   {/* Dispute button - appears when evidence is submitted but not yet released */}
                   {/* Dispute button - show for funded escrows on any milestone that is not released and not already disputed */}
-                  {isFunded && ms.status !== "released" && !disputedMs.has(idx) && (
+                  {isFunded && ms.status !== "released" && !disputedMs.has(idx) && isExternalWallet && (
                     <Button 
                       size="sm" 
                       onClick={() => setShowDisputeConfirm(idx)} 
@@ -300,7 +312,7 @@ export function ApproverAgreementDetail({ agr, walletAddress }: ApproverAgreemen
                     </span>
                   )}
                   
-                  {isFunded && (ms.status === "pending" || ms.status === "Completed") && !allReleased && ms.approved === false && !disputedMs.has(idx) && (
+                  {isFunded && (ms.status === "pending" || ms.status === "Completed") && !allReleased && ms.approved === false && !disputedMs.has(idx) && isExternalWallet && (
                     <Button size="sm" onClick={() => handleApprove(idx)} disabled={loadingMs === idx}
                       className="rounded-full bg-[#f0b400]/15 text-xs font-semibold text-[#f0b400] hover:bg-[#f0b400]/25 border border-[#f0b400]/20">
                       {loadingMs === idx ? t("flow.approving") : t("flow.approveMs")}
@@ -355,7 +367,7 @@ export function ApproverAgreementDetail({ agr, walletAddress }: ApproverAgreemen
           )}
 
           {/* Release button */}
-          {allApproved && !agr.released && !allReleased && (
+          {allApproved && !agr.released && !allReleased && isExternalWallet && (
             <div className="mt-4 rounded-xl border border-emerald-500/15 bg-emerald-500/5 p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
               <div>
                 <p className="text-sm font-semibold text-emerald-400">{t("flow.releaseAll")}</p>

--- a/app/dashboard/personal/page.tsx
+++ b/app/dashboard/personal/page.tsx
@@ -9,7 +9,8 @@ import { cn } from "@/lib/utils"
 import { ThalosLoader } from "@/components/thalos-loader"
 import { LanguageToggle, ThemeToggle, useLanguage } from "@/lib/i18n"
 import { useStellarWallet } from "@/lib/stellar-wallet"
-import { useCurrentAddress } from "@/lib/use-current-address"
+import { useCurrentAddress, useWalletType } from "@/lib/use-current-address"
+import { WalletGuard, WalletPrompt } from "@/components/shared/wallet-guard"
 import { useAuthStore } from "@/lib/auth-store"
 import { WalletAddress } from "@/components/ui/wallet-address"
 import { AlertTriangle } from "lucide-react"
@@ -328,6 +329,8 @@ export default function PersonalDashboardPage() {
   const { signTransaction, openWalletModal } = useStellarWallet();
   const walletAddress = useCurrentAddress();
   const { user: socialUser } = useAuthStore();
+  const walletType = useWalletType();
+  const isExternalWallet = walletType === "external";
   const [loading, setLoading] = useState(false);
 
   const [activeSection, setActiveSection] = useState("home");
@@ -1234,7 +1237,13 @@ const res = await getEscrowsByRole({ role: "approver", address: walletAddress })
 
                 {/* Milestones */}
                 <div className="flex flex-col gap-3 mb-6">
-                  <SellerMilestoneList agr={agr} agreements={agreements} setAgreements={setAgreements} t={t} />
+                  {isExternalWallet ? (
+                    <SellerMilestoneList agr={agr} agreements={agreements} setAgreements={setAgreements} t={t} />
+                  ) : (
+                    <WalletPrompt
+                      message="Connect and verify a wallet to submit evidence and manage this agreement."
+                    />
+                  )}
                 </div>
 
                 {allReleased && (
@@ -1330,6 +1339,14 @@ const res = await getEscrowsByRole({ role: "approver", address: walletAddress })
           {/* ══════ CREATE AGREEMENT ══════ */}
           {activeSection === "create" && (
             <div className="mx-auto max-w-4xl animate-in fade-in slide-in-from-bottom-2 duration-300">
+              {!isExternalWallet && !submitted ? (
+                <div className="pt-8">
+                  <WalletPrompt
+                    message="Connect and verify a wallet to operate escrow agreements on Thalos."
+                  />
+                </div>
+              ) : (
+              <>
               <div className="mb-6 flex items-center justify-between">
                 <h1 className="text-2xl font-semibold text-white">New Agreement</h1>
                 <Button onClick={() => { setActiveSection("agreements"); resetWizard() }}
@@ -1571,6 +1588,8 @@ const newAgr: Agreement = {
                   </div>
                 </div>
               )}
+              </>
+              )}
             </div>
           )}
         </main>
@@ -1578,7 +1597,7 @@ const newAgr: Agreement = {
       
       {/* Footer */}
       <Footer />
-
+      
       {/* Mobile Navigation */}
       <MobileNav
         activeSection={activeSection}

--- a/components/shared/wallet-guard.tsx
+++ b/components/shared/wallet-guard.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import { useStellarWallet } from "@/lib/stellar-wallet"
+import { useWalletType } from "@/lib/use-current-address"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+interface WalletGuardProps {
+  children: React.ReactNode
+  message?: string
+  className?: string
+}
+
+export function WalletGuard({ children, message, className }: WalletGuardProps) {
+  const { openWalletModal } = useStellarWallet()
+  const walletType = useWalletType()
+
+  if (walletType === "external") {
+    return <>{children}</>
+  }
+
+  return (
+    <WalletPrompt
+      onConnect={() => openWalletModal()}
+      message={message}
+      className={className}
+    />
+  )
+}
+
+export function WalletPrompt({
+  onConnect,
+  message,
+  className,
+}: {
+  onConnect?: () => void
+  message?: string
+  className?: string
+}) {
+  const { openWalletModal } = useStellarWallet()
+  const handleConnect = onConnect || (() => openWalletModal())
+
+  return (
+    <div className={cn("flex flex-col items-center gap-4 rounded-xl border border-[#f0b400]/20 bg-[#f0b400]/5 p-8 text-center", className)}>
+      <div className="flex h-14 w-14 items-center justify-center rounded-full bg-[#f0b400]/10">
+        <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#f0b400" strokeWidth="1.5">
+          <rect x="1" y="4" width="22" height="16" rx="2" />
+          <path d="M1 10h22" />
+        </svg>
+      </div>
+      <div>
+        <p className="text-base font-semibold text-[#f0b400]">Wallet Required</p>
+        <p className="mt-1 text-sm text-white/60 max-w-sm">
+          {message || "Connect and verify a wallet to operate escrow agreements on Thalos."}
+        </p>
+      </div>
+      <Button
+        onClick={handleConnect}
+        className="rounded-full bg-[#f0b400] px-6 text-sm font-semibold text-background hover:bg-[#f0b400]/90"
+      >
+        Connect Wallet
+      </Button>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #73 

## Description

In a non-custodial model a user can be logged in without an operating wallet. Escrow actions (create agreement, fund, approve milestone, release) must be blocked until the user has a connected and verified wallet, with a clear prompt to connect one.

### Changes

- **components/shared/wallet-guard.tsx** - New reusable `WalletGuard` and `WalletPrompt` components
- **app/dashboard/personal/page.tsx** - Gated create agreement wizard and seller evidence submission
- **app/dashboard/business/page.tsx** - Gated create agreement wizard, milestone actions, and release actions
- **app/dashboard/personal/ApproverAgreementDetail.tsx** - Gated fund, approve, release, and dispute actions

### Escrow entry points gated

| Entry Point | File |
|---|---|
| Create Agreement wizard (personal) | `app/dashboard/personal/page.tsx` |
| Create Agreement wizard (business) | `app/dashboard/business/page.tsx` |
| Submit Evidence (seller) | `app/dashboard/personal/page.tsx` |
| Fund Escrow | `app/dashboard/personal/ApproverAgreementDetail.tsx` |
| Approve Milestone | `app/dashboard/personal/ApproverAgreementDetail.tsx`, `app/dashboard/business/page.tsx` |
| Release Funds | `app/dashboard/personal/ApproverAgreementDetail.tsx`, `app/dashboard/business/page.tsx` |
| Raise Dispute | `app/dashboard/personal/ApproverAgreementDetail.tsx`, `app/dashboard/business/page.tsx` |
| Release All / Approve & Release All | `app/dashboard/business/page.tsx` |

### How it works

Uses `useWalletType()` (from `lib/use-current-address.tsx`) which returns `"external"` when a Freighter/xBull/LOBSTR wallet is connected. When `walletType !== "external"`, escrow actions are replaced with a **Wallet Required** prompt containing:
- Message: "Connect and verify a wallet to operate escrow agreements on Thalos."
- **Connect Wallet** button that opens the Stellar Wallets Kit modal

### Acceptance criteria

- [x] User without a verified wallet cannot start escrow actions
- [x] Clear prompt guides the user to connect/verify a wallet
- [x] Once a verified wallet exists, actions are enabled
- [x] `pnpm run build` passes