### PR TITLE
feat(auth): migrate existing orphan wallets to non-operational state (Issue #74)

### DIFF
--- a/scripts/012_migrate_orphan_wallets.sql
+++ b/scripts/012_migrate_orphan_wallets.sql
@@ -1,0 +1,22 @@
+-- Migration 012: Migrate existing orphan wallets to a non-operational state (Issue #74)
+
+BEGIN;
+
+-- 1. Null out orphan wallet_public_keys in auth_users
+-- We identify orphan wallets by checking if the user's primary wallet is a 'custodial' wallet auto-generated on signup.
+UPDATE auth_users
+SET wallet_public_key = NULL
+WHERE id IN (
+  SELECT au.id
+  FROM auth_users au
+  JOIN linked_wallets lw ON au.id = lw.user_id
+  WHERE lw.wallet_type = 'custodial' 
+    AND au.wallet_public_key = lw.wallet_address
+);
+
+-- 2. Remove auto-linked custodial wallet rows
+-- Deleting them ensures that the user has no operational wallets and will be prompted to connect one.
+DELETE FROM linked_wallets
+WHERE wallet_type = 'custodial';
+
+COMMIT;


### PR DESCRIPTION
Closes #74

### Description
This PR performs the data migration to transition existing orphan wallets (custodial wallets auto-generated on signup prior to M3) into a non-operational state. 

This is the data migration counterpart to the codebase changes already merged in PR #79 (Issue #71). It includes:
* `012_migrate_orphan_wallets.sql`: A migration script that nullifies the `wallet_public_key` field in `auth_users` for users utilizing custodial wallets and removes the custodial entries from the `linked_wallets` table.

### Rollback Notes
This migration deletes the auto-generated custodial wallets. Since these keys were orphans and no one has their secret keys, restoring them does not restore operational capability. However, to rollback:
1. **Prerequisite:** Ensure a snapshot/backup of the `auth_users` and `linked_wallets` tables is taken before execution.
2. **Reversion:** Restore the deleted `linked_wallets` records and revert the `wallet_public_key` values in `auth_users` from the backup.

### Dev Database Validation (Before/After Counts)
Below is the output of the counts before and after executing the queries on our local development Supabase database:

**Before migration:**
```
Count of custodial wallets in linked_wallets: 1
wallet_public_key for user before1@example.com: GABBEFORE1
```

**After migration:**
```
Count of custodial wallets in linked_wallets: 0
wallet_public_key for user before1@example.com: NULL (empty)
wallet_public_key for user before2@example.com: GABBEFORE2 (non-custodial, unchanged)
```
