### PR TITLE
feat: wallet ownership verification via challenge-response signing

### DIFF
--- a/components/profile/linked-wallets.tsx
+++ b/components/profile/linked-wallets.tsx
@@ -9,6 +9,7 @@ import { useStellarWallet } from "@/lib/stellar-wallet"
 import { useAuthStore } from "@/lib/auth-store"
 import {
   getWalletsWithBalances,
+  getWalletVerificationChallenge,
   linkWallet,
   updateWallet,
   unlinkWallet,
@@ -80,7 +81,7 @@ interface LinkedWalletsProps {
 
 export function LinkedWallets({ onWalletSelect, selectedWallet, showBalances = true }: LinkedWalletsProps) {
   const { t } = useLanguage()
-  const { address: connectedWallet, openWalletModal } = useStellarWallet()
+  const { address: connectedWallet, openWalletModal, signMessage } = useStellarWallet()
   const { token } = useAuthStore()
   const [wallets, setWallets] = useState<WalletWithBalance[]>([])
   const [isLoading, setIsLoading] = useState(true)
@@ -138,10 +139,36 @@ export function LinkedWallets({ onWalletSelect, selectedWallet, showBalances = t
     setError(null)
 
     try {
+      // Step 1: Request verification challenge from backend
+      const challengeResult = await getWalletVerificationChallenge(walletAddress, token)
+      if (!challengeResult.success || !challengeResult.data) {
+        // Backend may not support challenge endpoint yet — link without proof
+        const result = await linkWallet(
+          { wallet_address: walletAddress, wallet_type: "freighter" },
+          token
+        )
+        if (result.success) {
+          await loadWallets()
+          return true
+        }
+        setError(result.error || t("linkedWallets.linkError"))
+        return false
+      }
+
+      // Step 2: Sign the challenge message with the connected wallet
+      const signature = await signMessage(challengeResult.data.challenge)
+      if (!signature) {
+        setError(t("linkedWallets.signatureCancelled"))
+        return false
+      }
+
+      // Step 3: Link wallet with signature proof
       const result = await linkWallet(
         {
           wallet_address: walletAddress,
           wallet_type: "freighter",
+          signed_message: challengeResult.data.challenge,
+          signature,
         },
         token
       )
@@ -308,7 +335,7 @@ export function LinkedWallets({ onWalletSelect, selectedWallet, showBalances = t
               const typeInfo = walletTypeLabels[wallet.wallet_type] || walletTypeLabels.other
               const isSelected = selectedWallet === wallet.wallet_address
               const isConnected = connectedWallet === wallet.wallet_address
-              const isVerified = isConnected
+              const isVerified = wallet.is_verified
               const isEditing = editingLabel === wallet.id
 
               return (
@@ -371,9 +398,13 @@ export function LinkedWallets({ onWalletSelect, selectedWallet, showBalances = t
                               {t("linkedWallets.operatingWallet")}
                             </span>
                           )}
-                          {isVerified && (
+                          {isVerified ? (
                             <span className="rounded-full bg-blue-500/20 px-2 py-0.5 text-[10px] font-medium text-blue-400">
                               {t("linkedWallets.verified")}
+                            </span>
+                          ) : (
+                            <span className="rounded-full bg-amber-500/20 px-2 py-0.5 text-[10px] font-medium text-amber-400">
+                              {t("linkedWallets.pending")}
                             </span>
                           )}
                           {isConnected && (

--- a/lib/api/wallets.ts
+++ b/lib/api/wallets.ts
@@ -6,6 +6,7 @@ export interface LinkedWallet {
   wallet_type: "custodial" | "freighter" | "lobstr" | "xbull" | "albedo" | "other"
   label: string | null
   is_primary: boolean
+  is_verified: boolean
   linked_at: string
 }
 
@@ -95,6 +96,7 @@ export async function getWalletsWithAgreements(token: string): Promise<ApiRespon
       wallet_type: wallet.wallet_type as LinkedWallet["wallet_type"],
       label: (wallet.label as string | null) ?? null,
       is_primary: (wallet.is_primary as boolean) ?? false,
+      is_verified: (wallet.is_verified as boolean) ?? false,
       linked_at: wallet.linked_at as string,
       agreements_count: (wallet.agreements_count as number | undefined) ?? agreements.length,
       agreements,
@@ -121,12 +123,14 @@ export async function getWalletBalance(
   )
 }
 
-// Link a new wallet
+// Link a new wallet (with optional signature proof)
 export async function linkWallet(
   data: {
     wallet_address: string
     wallet_type: LinkedWallet["wallet_type"]
     label?: string
+    signed_message?: string
+    signature?: string
   },
   token: string
 ): Promise<ApiResponse<LinkedWallet>> {
@@ -136,6 +140,18 @@ export async function linkWallet(
       method: "POST",
       body: JSON.stringify(data),
     },
+    token
+  )
+}
+
+// Request a wallet verification challenge
+export async function getWalletVerificationChallenge(
+  walletAddress: string,
+  token: string
+): Promise<ApiResponse<{ challenge: string }>> {
+  return apiRequest<{ challenge: string }>(
+    `/wallets/verify-challenge?wallet_address=${encodeURIComponent(walletAddress)}`,
+    { method: "GET" },
     token
   )
 }

--- a/lib/stellar-wallet.tsx
+++ b/lib/stellar-wallet.tsx
@@ -16,6 +16,7 @@ type StellarWalletContextValue = {
   openWalletModal: (onConnected?: (address: string) => void, accountType?: "personal" | "enterprise") => Promise<void>
   disconnect: () => void
   signTransaction: (xdr: string, networkPassphrase: string) => Promise<{ signedTxXdr: string } | null>
+  signMessage: (message: string) => Promise<string | null>
   refreshProfile: () => Promise<void>
 }
 
@@ -143,6 +144,27 @@ export function StellarWalletProvider({ children }: { children: React.ReactNode 
         return null
       }
     },
+    }, [address]
+  )
+
+  const signMessage = useCallback(
+    async (message: string): Promise<string | null> => {
+      if (!address) return null
+      try {
+        const kit = await getKit()
+        if (kit && typeof (kit as any).signMessage === "function") {
+          const result = await (kit as any).signMessage(address, message)
+          return typeof result === "string" ? result : result?.signature ?? null
+        }
+        if (typeof window !== "undefined" && (window as any).freighter?.signMessage) {
+          const result = await (window as any).freighter.signMessage(message, address)
+          return typeof result === "string" ? result : result?.signature ?? null
+        }
+        return null
+      } catch {
+        return null
+      }
+    },
     [address]
   )
 
@@ -154,6 +176,7 @@ export function StellarWalletProvider({ children }: { children: React.ReactNode 
     openWalletModal,
     disconnect,
     signTransaction,
+    signMessage,
     refreshProfile,
   }
 


### PR DESCRIPTION
## Summary
Adds wallet ownership verification using a challenge-response signing flow (SEP-0043). Currently wallets are linked without proof of ownership — this PR adds cryptographic verification.

## Changes

### `lib/api/wallets.ts`
- Added `is_verified` field to `LinkedWallet` interface
- Added `getWalletVerificationChallenge(walletAddress, token)` — fetches challenge string from backend
- Extended `linkWallet` to accept optional `signed_message` + `signature` fields

### `lib/stellar-wallet.tsx`
- Added `signMessage(message: string)` to wallet context type and implementation
- Tries Stellar Wallets Kit `signMessage` first, falls back to Freighter direct API (`window.freighter.signMessage`)
- Returns signature string or `null` on cancellation/error

### `components/profile/linked-wallets.tsx`
- **Verification flow**: request challenge → sign via connected wallet → submit with signature
- **Graceful fallback**: if backend challenge endpoint returns error, links without proof (backward compatible)
- **Verified/Pending badges**: shows blue "Verified" badge when `is_verified === true`, amber "Pending" badge otherwise
- **UX**: friendly error toast when user cancels signature in wallet prompt

## Behavior
- New wallet link: requests challenge → wallet prompts user to sign → sends proof to backend
- Existing wallets: show Verified/Pending based on `is_verified` from API
- Wallet connect flow unchanged
- If backend doesn't have `/wallets/verify-challenge` endpoint yet, falls back to simple linking (no breakage)

## Acceptance Criteria
- [x] Challenge-response flow implemented in frontend
- [x] Signature sent with wallet link request
- [x] Verified/Pending badge per wallet
- [x] Graceful handling of cancelled signatures
- [ ] Backend `/wallets/verify-challenge` endpoint implemented (separate backend task)

Closes #67